### PR TITLE
[Fix] Add trimming for attribute value

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/ws/model/attribute/ItemAttributeResource.java
+++ b/src/main/java/com/epam/ta/reportportal/ws/model/attribute/ItemAttributeResource.java
@@ -16,6 +16,8 @@
 
 package com.epam.ta.reportportal.ws.model.attribute;
 
+import org.apache.commons.lang3.StringUtils;
+
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 import java.io.Serializable;
@@ -40,7 +42,7 @@ public class ItemAttributeResource implements Serializable {
 
 	public ItemAttributeResource(String key, String value) {
 		this.key = key;
-		this.value = value;
+		this.value = StringUtils.left(value, MAX_ATTRIBUTE_LENGTH);
 	}
 
 	public String getKey() {
@@ -56,7 +58,7 @@ public class ItemAttributeResource implements Serializable {
 	}
 
 	public void setValue(String value) {
-		this.value = value;
+		this.value = StringUtils.left(value, MAX_ATTRIBUTE_LENGTH);
 	}
 
 	@Override


### PR DESCRIPTION
Since the server allows attributes value only up to 128 symbols, all items with attributes value of more than 128 characters will not be created in ReportPortal at all. 

The suggestion is just to trim the value by 128 symbols.

The issue is similar to [this](https://github.com/reportportal/client-net/issues/57), but for the Java client.